### PR TITLE
change vnstat interface to an online interface

### DIFF
--- a/vnstatui-setup.sh
+++ b/vnstatui-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vnstat_iface=$(ls /var/lib/vnstat)
+vnstat_iface=$(ip route show to match 8.8.8.8 | grep default -m 1 | awk '{print $5}')
 
 # uninstall eventually already installed vnstatui
 if [ -f /usr/bin/vnstatui ]; then


### PR DESCRIPTION
Interface set in setup script in my case is pointing to `vnstat.db` file which is the wrong interface.